### PR TITLE
fix: build issue with typescript in counter/core

### DIFF
--- a/counter/core/lib/entities/counter.ts
+++ b/counter/core/lib/entities/counter.ts
@@ -5,15 +5,11 @@ export class Counter {
     this.count = startNumber;
   }
 
-  increment(qty: number) {
-    if(qty !== null) {
-      this.count += qty;
-    }
+  increment(qty?: number) {
+    this.count += qty ? qty : 1;
   }
 
-  decrement(qty: number) {
-    if(qty !== null) {
-      this.count -= qty;
-    }
+  decrement(qty?: number) {
+    this.count -= qty ? qty : 1;
   }
 }


### PR DESCRIPTION
This Pull Request introduces changes to the Counter entity. Specifically, the following modifications were made:

1. Implemented a default behavior for the Counter entity when the `qty` argument is not provided in Counter methods.
  
2. Changed the `qty` argument  in the Counter methods to be optional instead of mandatory. This offers more flexibility when using the Counter entity, as it no longer requires the `qty` argument to be explicitly provided every time a Counter instance is created.

These changes aim to fix the build issue with typescript and robustness of the Counter entity by making it more flexible and resilient to different usage scenarios. Please review and let me know if you have any comments or suggestions.

Closes #101 